### PR TITLE
Improve the stability of Bilibili downloader

### DIFF
--- a/bilix/download/downloader_bilibili.py
+++ b/bilix/download/downloader_bilibili.py
@@ -318,10 +318,16 @@ class DownloaderBilibili(BaseDownloaderPart):
         _, _, bvids = await api.get_up_info(self.client, url_or_mid, pn, ps, order, keyword)
         bvids = bvids[:num]
         func = self.get_series if series else self.get_video
+
         # noinspection PyArgumentList
-        await asyncio.gather(
-            *[func(f'https://www.bilibili.com/video/{bv}', quality=quality, codec=codec,
-                   image=image, subtitle=subtitle, dm=dm, only_audio=only_audio, hierarchy=hierarchy) for bv in bvids])
+        
+        for bv in bvids:
+            try:
+                await asyncio.gather(
+                    *[func(f'https://www.bilibili.com/video/{bv}', quality=quality, codec=codec,
+                        image=image, subtitle=subtitle, dm=dm, only_audio=only_audio, hierarchy=hierarchy)])
+            except AttributeError as e:
+                logger.warning(f'{e} {bv}')
 
     async def get_series(self, url: str, quality: Union[str, int] = 0, image=False, subtitle=False,
                          dm=False, only_audio=False, p_range: Sequence[int] = None, codec: str = '',

--- a/bilix/download/downloader_bilibili.py
+++ b/bilix/download/downloader_bilibili.py
@@ -348,7 +348,7 @@ class DownloaderBilibili(BaseDownloaderPart):
         """
         try:
             video_info = await api.get_video_info(self.client, url)
-        except AttributeError as e:
+        except Exception as e:
             logger.warning(f'{e} {url}')
             return
         title = video_info.title


### PR DESCRIPTION
原来的写法虽然更加简洁，但是在网络不太好的情况下（大概率发生），一个视频的下载失败，就会让整个up主的下载全部退出，不太鲁棒

新的写法繁复了一些，但是不会因为单个视频或者系列的下载失败而退出，可以下载完up主大部分视频