### PR TITLE
improve hdr support

### DIFF
--- a/bilix/api/bilibili.py
+++ b/bilix/api/bilibili.py
@@ -9,7 +9,11 @@ import json5
 from bilix.dm import parse_view
 from bilix.utils import req_retry, legal_title
 
-_dft_headers = {'user-agent': 'PostmanRuntime/7.29.0', 'referer': 'https://www.bilibili.com'}
+dft_client_settings = {
+    'headers': {'user-agent': 'PostmanRuntime/7.29.0', 'referer': 'https://www.bilibili.com'},
+    'cookies': {'CURRENT_FNVAL': '4048'},
+    'http2': True
+}
 
 
 async def get_cate_meta(client: httpx.AsyncClient) -> dict:
@@ -264,9 +268,9 @@ if __name__ == '__main__':
 
     # result = asyncio.run(get_cate_meta())
     # rich.print(result)
-    _dft_client = httpx.AsyncClient(headers=_dft_headers, http2=True)
+    client = httpx.AsyncClient(**dft_client_settings)
     result = asyncio.run(get_video_info(
-        _dft_client,
+        client,
         "https://www.bilibili.com/video/BV1fK4y1t7hj"
     ))
     rich.print(result)

--- a/bilix/download/downloader_bilibili.py
+++ b/bilix/download/downloader_bilibili.py
@@ -78,7 +78,7 @@ class DownloaderBilibili(BaseDownloaderPart):
         :param speed_limit: 下载速度限制，单位B/s
         :param progress: 进度对象，不提供则使用rich命令行进度
         """
-        cookies = {'SESSDATA': sess_data}
+        cookies = {'SESSDATA': sess_data, 'CURRENT_FNVAL': '4048'}
         headers = {'user-agent': 'PostmanRuntime/7.29.0', 'referer': 'https://www.bilibili.com'}
         client = httpx.AsyncClient(headers=headers, cookies=cookies, http2=True)
         super(DownloaderBilibili, self).__init__(client, videos_dir, part_concurrency, speed_limit=speed_limit,

--- a/bilix/download/downloader_bilibili.py
+++ b/bilix/download/downloader_bilibili.py
@@ -78,9 +78,8 @@ class DownloaderBilibili(BaseDownloaderPart):
         :param speed_limit: 下载速度限制，单位B/s
         :param progress: 进度对象，不提供则使用rich命令行进度
         """
-        cookies = {'SESSDATA': sess_data, 'CURRENT_FNVAL': '4048'}
-        headers = {'user-agent': 'PostmanRuntime/7.29.0', 'referer': 'https://www.bilibili.com'}
-        client = httpx.AsyncClient(headers=headers, cookies=cookies, http2=True)
+        client = httpx.AsyncClient(**api.dft_client_settings)
+        client.cookies.set('SESSDATA', sess_data)
         super(DownloaderBilibili, self).__init__(client, videos_dir, part_concurrency, speed_limit=speed_limit,
                                                  progress=progress)
         self.speed_limit = speed_limit

--- a/bilix/info/informer_bilibili.py
+++ b/bilix/info/informer_bilibili.py
@@ -13,9 +13,8 @@ __all__ = ['InformerBilibili']
 
 class InformerBilibili(BaseInformer):
     def __init__(self, sess_data: str = ''):
-        cookies = {'SESSDATA': sess_data, 'CURRENT_FNVAL': '4048'}
-        headers = {'user-agent': 'PostmanRuntime/7.29.0', 'referer': 'https://www.bilibili.com'}
-        client = httpx.AsyncClient(headers=headers, cookies=cookies, http2=True)
+        client = httpx.AsyncClient(**api.dft_client_settings)
+        client.cookies.set('SESSDATA', sess_data)
         super().__init__(client)
         self.type_map = {
             'up': self.info_up,

--- a/bilix/info/informer_bilibili.py
+++ b/bilix/info/informer_bilibili.py
@@ -13,7 +13,7 @@ __all__ = ['InformerBilibili']
 
 class InformerBilibili(BaseInformer):
     def __init__(self, sess_data: str = ''):
-        cookies = {'SESSDATA': sess_data}
+        cookies = {'SESSDATA': sess_data, 'CURRENT_FNVAL': '4048'}
         headers = {'user-agent': 'PostmanRuntime/7.29.0', 'referer': 'https://www.bilibili.com'}
         client = httpx.AsyncClient(headers=headers, cookies=cookies, http2=True)
         super().__init__(client)

--- a/examples/use_of_api.py
+++ b/examples/use_of_api.py
@@ -12,13 +12,7 @@ from httpx import AsyncClient
 async def main():
     # 需要先实例化一个用来进行http请求的client
     # first we should initialize a http client
-    client = AsyncClient(
-        headers={'user-agent': 'PostmanRuntime/7.29.0', 'referer': 'https://www.bilibili.com'},
-        # bilibili 全面支持http2协议，因此我们打开http2，这会使得我们的速度更快，同时给b站服务器造成的压力更小
-        # bilibili support http2 protocol, turn http2 on, and it will make network request faster and cause less
-        # pressure to the server
-        http2=True
-    )
+    client = AsyncClient(**bilibili.dft_client_settings)
     data = await bilibili.get_video_info(client, 'https://www.bilibili.com/bangumi/play/ep90849')
     print(data)
 

--- a/tests/api/test_bilibili_api.py
+++ b/tests/api/test_bilibili_api.py
@@ -4,8 +4,7 @@ import asyncio
 from datetime import datetime, timedelta
 import bilix.api.bilibili as api
 
-client = httpx.AsyncClient(headers={'user-agent': 'PostmanRuntime/7.29.0', 'referer': 'https://www.bilibili.com'},
-                           http2=True)
+client = httpx.AsyncClient(**api.dft_client_settings)
 
 
 # https://stackoverflow.com/questions/61022713/pytest-asyncio-has-a-closed-event-loop-but-only-when-running-all-tests

--- a/tests/download/test_bilibili_download.py
+++ b/tests/download/test_bilibili_download.py
@@ -10,21 +10,20 @@ async def test_choose_quality():
     import bilix.api.bilibili as api
     from httpx import AsyncClient
 
-    client = AsyncClient(headers={'user-agent': 'PostmanRuntime/7.29.0', 'referer': 'https://www.bilibili.com'},
-                         cookies={'SESSDATA': os.getenv('BILI_TOKEN')}, http2=True)
+    client = AsyncClient(**api.dft_client_settings)
+    client.cookies.set('SESSDATA', os.getenv('BILI_TOKEN'))
     # dolby
     data = await api.get_video_info(client, "https://www.bilibili.com/video/BV13L4y1K7th")
     try:
-        video_info, audio_info = choose_quality(data.dash, data.support_formats, quality=999, codec=":ec-3")
+        video, audio = choose_quality(data, quality=999, codec=":ec-3")
     except ValueError:
         assert not os.getenv("BILI_TOKEN")
     # normal
-    choose_quality(data.dash, data.support_formats, quality="360P", codec="hev")
+    choose_quality(data, quality="360P", codec="hev")
     # hi-res
     data = await api.get_video_info(client, "https://www.bilibili.com/video/BV16K411S7sk")
     try:
-        video_info, audio_info = choose_quality(data.dash, data.support_formats,
-                                                quality='1080P', codec="hev:fLaC")
+        video, audio = choose_quality(data, quality='1080P', codec="hev:fLaC")
     except ValueError:
         assert not os.getenv("BILI_TOKEN")
     await client.aclose()


### PR DESCRIPTION
部分视频探测不到 HDR 清晰度，见问题 https://github.com/HFrost0/bilix/issues/81

请求网页时即使带上大会员的 SESSDATA，默认也不返回 HDR 清晰度的选项，因此你的 info 命令解析不到。在加上 Cookie CURRENT_FNVAL=4048 之后，返回的页面中就有了 HDR 选项。（4048是浏览器正常访问页面时携带的值，理论上可以覆盖到 8K 分辨率）

本次 PR 增强了获取 HDR 视频的能力。

pytest 结果如下：

```
% pytest tests/api/test_bilibili_api.py
================================================= test session starts =================================================
platform darwin -- Python 3.10.8, pytest-7.2.0, pluggy-1.0.0
rootdir: /Users/cws/Documents/GitHub/bilix
plugins: asyncio-0.20.3, anyio-3.6.2
asyncio: mode=strict
collected 9 items                                                                                                     

tests/api/test_bilibili_api.py .........                                                                        [100%]

================================================== 9 passed in 3.61s ==================================================
````