### PR TITLE
Url-encoding sess_data if it's not encoded

### DIFF
--- a/bilix/download/downloader_bilibili.py
+++ b/bilix/download/downloader_bilibili.py
@@ -1,5 +1,7 @@
 import asyncio
 import functools
+import re
+import urllib.parse
 from typing import Union, Sequence
 import aiofiles
 import httpx
@@ -33,6 +35,11 @@ class DownloaderBilibili(BaseDownloaderPart):
         :param progress: 进度对象，不提供则使用rich命令行进度
         """
         client = httpx.AsyncClient(**api.dft_client_settings)
+
+        # url-encoding sess_data if it's not encoded
+        if re.search(r';|/|\?|:|@|&|=|\+|$|,', sess_data):
+            sess_data = urllib.parse.quote_plus(sess_data)
+
         client.cookies.set('SESSDATA', sess_data)
         super(DownloaderBilibili, self).__init__(
             client=client,

--- a/bilix/info/informer_bilibili.py
+++ b/bilix/info/informer_bilibili.py
@@ -1,12 +1,15 @@
 import asyncio
+import re
+import urllib.parse
+
 import httpx
 from rich.tree import Tree
 
 import bilix.api.bilibili as api
-from bilix.log import logger
-from bilix.utils import req_retry, convert_size, parse_bilibili_url
 from bilix.handle import Handler
 from bilix.info.base_informer import BaseInformer
+from bilix.log import logger
+from bilix.utils import req_retry, convert_size, parse_bilibili_url
 
 __all__ = ['InformerBilibili']
 
@@ -14,6 +17,11 @@ __all__ = ['InformerBilibili']
 class InformerBilibili(BaseInformer):
     def __init__(self, sess_data: str = ''):
         client = httpx.AsyncClient(**api.dft_client_settings)
+
+        # url-encoding sess_data if it's not encoded
+        if re.search(r';|/|\?|:|@|&|=|\+|$|,', sess_data):
+            sess_data = urllib.parse.quote_plus(sess_data)
+
         client.cookies.set('SESSDATA', sess_data)
         super().__init__(client)
         self.type_map = {


### PR DESCRIPTION
修复 https://github.com/HFrost0/bilix/issues/112 中发现的问题。
ref:
https://stackoverflow.com/questions/55426439/is-there-an-idempotent-version-of-urllib-parse-quote
https://stackoverflow.com/questions/1547899/which-characters-make-a-url-invalid