### PR TITLE
feat: brew install

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ dist/
 docs/.vitepress/dist
 docs/.vitepress/cache
 node_modules
+.venv

--- a/README.md
+++ b/README.md
@@ -41,6 +41,12 @@ Extensible Python module suitable for more download scenarios.
 pip install bilix
 ```
 
+### Mac
+
+```shell
+brew install bilix
+```
+
 ## Usage Example
 
 * If you prefer to use command line interface (cli)

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Extensible Python module suitable for more download scenarios.
 pip install bilix
 ```
 
-### Mac
+for macOS, you can also install `bilix` by `brew`
 
 ```shell
 brew install bilix

--- a/docs/en/install.md
+++ b/docs/en/install.md
@@ -5,6 +5,10 @@ bilix is a powerful Python asynchronous video download tool that requires two st
    ```shell
    pip install bilix
    ```
+   If you are a macOS user, you can also use `brew` to install:
+   ```shell
+    brew install bilix
+    ```
 
 2. [FFmpeg](https://ffmpeg.org) ：A command-line video tool for compositing downloaded audio and video
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -5,6 +5,11 @@ bilix是一个强大的Python异步视频下载工具，安装它需要完成两
    ```shell
    pip install bilix
    ```
+   
+   如果你是macOS用户，可以使用brew安装：
+   ```shell
+    brew install bilix
+    ```
 
 2. [FFmpeg](https://ffmpeg.org) ：一个命令行视频工具，用于合成下载的音频和视频
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -6,7 +6,7 @@ bilix是一个强大的Python异步视频下载工具，安装它需要完成两
    pip install bilix
    ```
    
-   如果你是macOS用户，可以使用brew安装：
+   如果你是macOS用户，也可以使用`brew`安装：
    ```shell
     brew install bilix
     ```


### PR DESCRIPTION
 通过 https://github.com/Homebrew/homebrew-core/pull/136085 关闭 #19 。

另外考虑到大部分开发者会使用 venv + pip 的形式安装依赖，在 gitignore 中添加了 .venv 文件夹。

