### PR TITLE
BiliBili: 从 API 解析 video_info

### DIFF
--- a/bilix/exception.py
+++ b/bilix/exception.py
@@ -28,6 +28,10 @@ class APIUnsupportedError(APIError):
     """The resource parse is not supported yet"""
 
 
+class APIBannedError(APIError):
+    """API request is banned"""
+
+
 class HandleError(Exception):
     """the error related to bilix cli handle"""
 

--- a/bilix/sites/bilibili/api.py
+++ b/bilix/sites/bilibili/api.py
@@ -331,8 +331,10 @@ class VideoInfo(BaseModel):
         :param init_dash: 原样添加到 VideoInfo 对象中
         :param init_other: 原样添加到 VideoInfo 对象中，但如果是 None 则会被初始化为 []
         """
-        if init_other is None: init_other = []
-        if isinstance(response, str): response = json.loads(response)
+        if init_other is None:
+            init_other = []
+        if isinstance(response, str):
+            response = json.loads(response)
         
         assert isinstance(response, dict)
         if response['code'] != 0:
@@ -462,14 +464,14 @@ async def get_video_info_from_api(client: httpx.AsyncClient, url) -> VideoInfo:
     aid, bvid, page_num = parse_ids_from_url(url)
     page_num = page_num or 1
 
-    video_info = await get_basic_video_info_from_api(client, aid=aid, bvid=bvid, selected_page_num=page_num)
-    video_info.dash, video_info.other = await get_video_dashAndDurl_from_api(client, aid=aid, bvid=bvid, cid=video_info.cid)
+    video_info = await get_video_basic_info_from_api(client, aid=aid, bvid=bvid, selected_page_num=page_num)
+    video_info.dash, video_info.other = await get_video_dash_and_durl_from_api(client, aid=aid, bvid=bvid, cid=video_info.cid)
 
     return video_info
 
 
 @raise_api_error
-async def get_video_dashAndDurl_from_api(client: httpx.AsyncClient,* ,
+async def get_video_dash_and_durl_from_api(client: httpx.AsyncClient,* ,
                          aid: Optional[int] = None, bvid: Optional[str] = None, cid: int) -> Tuple[Dash, List[Media]]:
     """
     从 api 获取视频的 dash 和 durl
@@ -481,8 +483,10 @@ async def get_video_dashAndDurl_from_api(client: httpx.AsyncClient,* ,
               'fnval': 4048, # 请求 dash 格式的全部可用流
               'fourk': 1, # 请求 4k 资源
               'fnver': 0, 'platform': 'pc', 'otype': 'json'}
-    if bvid is not None: params['bvid'] = bvid
-    elif aid is not None: params['avid'] = aid
+    if bvid is not None:
+        params['bvid'] = bvid
+    elif aid is not None:
+        params['avid'] = aid
     dash_response = await req_retry(client, DASH_API_URL, params=params, follow_redirects=True)
     dash_json = json.loads(dash_response.text)    
     assert dash_json['code'] == 0, f"获取视频 dash/durl 失败，原因：{dash_json['message']}"
@@ -499,15 +503,17 @@ async def get_video_dashAndDurl_from_api(client: httpx.AsyncClient,* ,
     return dash, other
 
 @raise_api_error
-async def get_basic_video_info_from_api(client: httpx.AsyncClient,*, aid:Optional[int], bvid:Optional[str], selected_page_num:int = 1) -> VideoInfo:
+async def get_video_basic_info_from_api(client: httpx.AsyncClient,*, aid:Optional[int], bvid:Optional[str], selected_page_num:int = 1) -> VideoInfo:
     """
     通过 view api 获取视频信息，不包括 dash 或 durl(other) 资源
     """
     API_URL = 'https://api.bilibili.com/x/web-interface/view'
     assert aid or bvid
     params = {}
-    if bvid: params = {'bvid': bvid}
-    elif aid: params = {'avid': aid}
+    if bvid:
+        params = {'bvid': bvid}
+    elif aid:
+        params = {'avid': aid}
     r = await req_retry(client, API_URL, params=params, follow_redirects=True)
     raw_json = json.loads(r.text)
     basic_video_info_without_DashAndDurl = VideoInfo.parse_response_from_basic_video_info_api(raw_json, selected_page_num=selected_page_num)

--- a/bilix/sites/bilibili/api.py
+++ b/bilix/sites/bilibili/api.py
@@ -8,6 +8,7 @@ from typing import Union, List, Tuple, Dict, Optional
 import json5
 from danmakuC.bilibili import parse_view
 from bilix.download.utils import req_retry, raise_api_error
+from bilix.sites.bilibili.utils import parse_ids_from_url
 from bilix.utils import legal_title
 from bilix.exception import APIError, APIResourceError, APIUnsupportedError
 import hashlib
@@ -21,7 +22,7 @@ dft_client_settings = {
 
 
 @raise_api_error
-async def get_cate_meta(client: httpx.AsyncClient()) -> dict:
+async def get_cate_meta(client: httpx.AsyncClient) -> dict:
     """
     获取b站分区元数据
 
@@ -320,13 +321,58 @@ class VideoInfo(BaseModel):
     img_url: str
     status: Status
     bvid: str = None
-    dash: Dash = None
-    other: List[Media] = None  # flv, mp4
+    dash: Optional[Dash] = None
+    other: Optional[List[Media]] = None  # flv, mp4
+
+
+    @staticmethod
+    def parse_response_from_basic_video_info_api(response: Union[dict, str],* , init_dash: Optional[Dash]=None, init_other: Optional[List]=None, selected_page_num: int=1):
+        """
+        :param init_dash: 原样添加到 VideoInfo 对象中
+        :param init_other: 原样添加到 VideoInfo 对象中，但如果是 None 则会被初始化为 []
+        """
+        if init_other is None: init_other = []
+        if isinstance(response, str): response = json.loads(response)
+        
+        assert isinstance(response, dict)
+        if response['code'] != 0:
+            raise APIResourceError(response['message'], response['message'])
+
+        title = legal_title(response['data']['title'])
+        h1_title = title # TODO: 根据视频类型，使 h1_title 与实际网页标题的格式一致
+        aid = int(response['data']['aid'])
+        bvid = response['data']['bvid']
+        assert isinstance(bvid, str)
+        cid = int(response['data']['cid']) # NOTE: 这里的 cid 是 p1 的 cid
+
+        status = Status(**response['data']['stat'])
+
+        base_url = f"https://www.bilibili.com/video/{bvid}/" if bvid else None
+        base_url = f"https://www.bilibili.com/video/av{aid}/" if aid else base_url
+        assert base_url is not None
+        pages = []
+        p = None
+        for idx, i in enumerate(response['data']['pages']):
+            page_num = int(i['page'])
+            if page_num == selected_page_num:
+                p = idx # selected_page_num 的分p 在 pages 列表中的 index 位置
+            p_url = f"{base_url}?p={page_num}"
+            p_name = f"P{page_num}-{i['part']}"
+            pages.append(Page(p_name=p_name, p_url=p_url))
+
+        assert p is not None, f"没有找到分P: p{selected_page_num}，请检查输入"
+
+        img_url = response['data']['pic']
+
+        video_info = VideoInfo(title=title, h1_title=h1_title, aid=aid, cid=cid, status=status,
+                               p=p, pages=pages, img_url=img_url, bvid=bvid, dash=init_dash, other=init_other)
+        return video_info
+
 
     @staticmethod
     def parse_html(url, html: str):
         if "window._riskdata_" in html:
-            raise APIError("web 前端访问可能被风控，请尝试打开浏览器通过验证码、更换 IP 或使用 API 后重试", html)
+            raise APIError("web 前端访问可能被风控，请尝试打开浏览器通过验证码挑战/更换 IP/使用 API", html)
         init_info = re.search(r'<script>window.__INITIAL_STATE__=({.*});\(', html).groups()[0]  # this line may raise
         init_info = json.loads(init_info)
         if len(init_info.get('error', {})) > 0:
@@ -392,10 +438,81 @@ class VideoInfo(BaseModel):
 
 
 @raise_api_error
-async def get_video_info(client: httpx.AsyncClient, url) -> VideoInfo:
+async def get_video_info(client: httpx.AsyncClient, url, use_api: bool = True) -> VideoInfo:
+    if use_api and (
+        '/av' in url or '/BV' in url # TODO: 暂时只支持 bv 和 av，不支持 ep 等其他形式的 URL
+        ):
+        return await get_video_info_from_api(client, url)
+    # else: by parsing webpage(html)
+    return await get_video_info_from_webpage(client, url)
+
+
+@raise_api_error
+async def get_video_info_from_webpage(client: httpx.AsyncClient, url) -> VideoInfo:
     res = await req_retry(client, url, follow_redirects=True)
     video_info = VideoInfo.parse_html(url, res.text)
     return video_info
+
+
+@raise_api_error
+async def get_video_info_from_api(client: httpx.AsyncClient, url) -> VideoInfo:
+    """
+    TODO: 暂时只支持 av/bvid 的普通视频，不支持 ep
+    """
+    aid, bvid, page_num = parse_ids_from_url(url)
+    page_num = page_num or 1
+
+    video_info = await get_basic_video_info_from_api(client, aid=aid, bvid=bvid, selected_page_num=page_num)
+    video_info.dash, video_info.other = await get_video_dashAndDurl_from_api(client, aid=aid, bvid=bvid, cid=video_info.cid)
+
+    return video_info
+
+
+@raise_api_error
+async def get_video_dashAndDurl_from_api(client: httpx.AsyncClient,* ,
+                         aid: Optional[int] = None, bvid: Optional[str] = None, cid: int) -> Tuple[Dash, List[Media]]:
+    """
+    从 api 获取视频的 dash 和 durl
+    """
+    assert cid is not None and (aid is not None or bvid is not None)
+    DASH_API_URL = 'https://api.bilibili.com/x/player/playurl'
+    params = {'cid': cid,
+              'qn': 116, # 1080P60（请求 DASH 会取到所有分辨率的流地址，应该不用设置 qn）
+              'fnval': 16, # 16->请求 dash 格式, 1-> durl 格式
+              'fourk': 1, # 请求 4k 资源
+              'fnver': 0, 'platform': 'pc', 'otype': 'json'}
+    if bvid is not None: params['bvid'] = bvid
+    elif aid is not None: params['avid'] = aid
+    dash_response = await req_retry(client, DASH_API_URL, params=params, follow_redirects=True)
+    dash_json = json.loads(dash_response.text)    
+    assert dash_json['code'] == 0, f"获取视频 dash/durl 失败，原因：{dash_json['message']}"
+    dash, other = None, []
+    if 'dash' in dash_json['data']:
+        dash = Dash.from_dict(dash_json)
+    if 'durl' in dash_json['data']:
+        # 请求了 dash ，API 应该永远不会返回 durl 资源。解析一下以防万一
+        assert len(dash_json['data']['durl']) == 1, "durl 中返回了多个视频流，这可能是错误？请报告"
+        for i in dash_json['data']['durl']:
+            suffix = re.search(r'\.([a-zA-Z0-9]+)\?', i['url']).group(1)
+            other.append(Media(base_url=i['url'], backup_url=i['backup_url'], size=i['size'], suffix=suffix))
+
+    return dash, other
+
+@raise_api_error
+async def get_basic_video_info_from_api(client: httpx.AsyncClient,*, aid:Optional[int], bvid:Optional[str], selected_page_num:int = 1) -> VideoInfo:
+    """
+    通过 view api 获取视频信息，不包括 dash 或 durl(other) 资源
+    """
+    API_URL = 'https://api.bilibili.com/x/web-interface/view'
+    assert aid or bvid
+    params = {}
+    if bvid: params = {'bvid': bvid}
+    elif aid: params = {'avid': aid}
+    r = await req_retry(client, API_URL, params=params, follow_redirects=True)
+    raw_json = json.loads(r.text)
+    basic_video_info_without_DashAndDurl = VideoInfo.parse_response_from_basic_video_info_api(raw_json, selected_page_num=selected_page_num)
+    
+    return basic_video_info_without_DashAndDurl
 
 
 @raise_api_error

--- a/bilix/sites/bilibili/api.py
+++ b/bilix/sites/bilibili/api.py
@@ -435,14 +435,14 @@ async def _get_video_info_from_api(client: httpx.AsyncClient, url) -> VideoInfo:
     page_num = page_num or 1
     assert isinstance(page_num, int) and page_num >= 1
 
-    video_info = await get_video_basic_info_from_api(client, aid=aid, bvid=bvid, selected_page_num=page_num)
-    video_info.dash, video_info.other = await get_video_dash_and_durl_from_api(client, aid=aid, bvid=bvid, cid=video_info.cid)
+    video_info = await _get_video_basic_info_from_api(client, aid=aid, bvid=bvid, selected_page_num=page_num)
+    video_info.dash, video_info.other = await _get_video_dash_and_durl_from_api(client, aid=aid, bvid=bvid, cid=video_info.cid)
 
     return video_info
 
 
 @raise_api_error
-async def get_video_dash_and_durl_from_api(client: httpx.AsyncClient,* ,
+async def _get_video_dash_and_durl_from_api(client: httpx.AsyncClient,* ,
                          aid: Optional[int] = None, bvid: Optional[str] = None, cid: int) -> Tuple[Dash, List[Media]]:
     """
     从 api 获取视频的 dash 和 durl
@@ -474,7 +474,7 @@ async def get_video_dash_and_durl_from_api(client: httpx.AsyncClient,* ,
     return dash, other
 
 @raise_api_error
-async def get_video_basic_info_from_api(client: httpx.AsyncClient,*, aid:Optional[int], bvid:Optional[str], selected_page_num:int = 1) -> VideoInfo:
+async def _get_video_basic_info_from_api(client: httpx.AsyncClient,*, aid:Optional[int], bvid:Optional[str], selected_page_num:int = 1) -> VideoInfo:
     """
     通过 view api 获取视频的基本信息，不包括 dash 或 durl(other) 视频流资源
     """

--- a/bilix/sites/bilibili/api.py
+++ b/bilix/sites/bilibili/api.py
@@ -395,7 +395,7 @@ class VideoInfo(BaseModel):
 
 
 @raise_api_error
-async def get_video_info(client: httpx.AsyncClient, url, api_only: bool = True) -> VideoInfo:
+async def get_video_info(client: httpx.AsyncClient, url, api_only: bool = False) -> VideoInfo:
     """
     默认访问视频页 HTML 内嵌的 JSON 获取视频信息，如果失败则通过 API 获取。
 

--- a/bilix/sites/bilibili/api.py
+++ b/bilix/sites/bilibili/api.py
@@ -325,6 +325,8 @@ class VideoInfo(BaseModel):
 
     @staticmethod
     def parse_html(url, html: str):
+        if "window._riskdata_" in html:
+            raise APIError("web 前端访问可能被风控，请尝试打开浏览器通过验证码、更换 IP 或使用 API 后重试", html)
         init_info = re.search(r'<script>window.__INITIAL_STATE__=({.*});\(', html).groups()[0]  # this line may raise
         init_info = json.loads(init_info)
         if len(init_info.get('error', {})) > 0:

--- a/bilix/sites/bilibili/api.py
+++ b/bilix/sites/bilibili/api.py
@@ -478,7 +478,7 @@ async def get_video_dashAndDurl_from_api(client: httpx.AsyncClient,* ,
     DASH_API_URL = 'https://api.bilibili.com/x/player/playurl'
     params = {'cid': cid,
               'qn': 116, # 1080P60（请求 DASH 会取到所有分辨率的流地址，应该不用设置 qn）
-              'fnval': 16, # 16->请求 dash 格式, 1-> durl 格式
+              'fnval': 4048, # 请求 dash 格式的全部可用流
               'fourk': 1, # 请求 4k 资源
               'fnver': 0, 'platform': 'pc', 'otype': 'json'}
     if bvid is not None: params['bvid'] = bvid

--- a/bilix/sites/bilibili/informer.py
+++ b/bilix/sites/bilibili/informer.py
@@ -36,7 +36,14 @@ class InformerBilibili(DownloaderBilibili):
     async def info_video(self, url: str):
         video_info = await api.get_video_info(self.client, url)
         if video_info.dash is None:
-            return logger.warning(f'{video_info.h1_title} 需要大会员或该地区不支持')
+            logger.warning(f'{video_info.h1_title} 未解析到 dash 资源（可能需要大会员或该地区不支持）')
+
+        if video_info.other:
+            logger.info(f'{video_info.h1_title} 解析到 durl 资源')
+            return rprint(video_info.other) # TODO: 把这一大托 print 出来有点丑
+        
+        if not video_info.dash and not video_info.other:
+            return logger.warning(f'{video_info.h1_title} dash 和 durl 资源均未被解析到（可能需要大会员或该地区不支持）')
 
         async def ensure_size(m: api.Media):
             if m.size is None:

--- a/bilix/sites/bilibili/utils.py
+++ b/bilix/sites/bilibili/utils.py
@@ -1,0 +1,37 @@
+import re
+
+
+def parse_ids_from_url(UrlOrString: str):
+    """
+    aid, bvid, page_num = parse_ids_from_url(UrlOrString)
+
+    例如：
+    ```
+    [0] https://www.bilibili.com/video/av170001
+    > aid = 170001, bvid = None, page_num = None
+    [1] http://www.bilibili.com/video/BV1Xx41117Tz/?ba=labala&p=3#time=1234
+    > aid = None, bvid = "BV1Xx41117Tz", page_num = 3
+    [2] av170001
+    > aid = 170001, bvid = None, page_num = None
+    [3] BV1sE411w7tQ?p=2
+    > aid = None, bvid = "BV1sE411w7tQ", page_num = 2
+    ```
+    """
+
+    bvid = aid = page_num = None
+    if re.match(r'https?://www.bilibili.com/video/BV\w+', UrlOrString) or re.match(r'BV\w+', UrlOrString):
+        bvid = re.search(r'BV(\w+)', UrlOrString).groups()[0]
+        assert bvid.isalnum()
+        assert isinstance(bvid, str)
+    elif re.match(r'https?://www.bilibili.com/video/av\d+', UrlOrString) or re.match(r'av\d+', UrlOrString):
+        aid = re.search(r'av(\d+)', UrlOrString).groups()[0]
+        assert aid.isdigit()
+        aid = int(aid)
+
+    # ?p=123 or &p=123
+    if re.match(r'.*[?&]p=(\d+)', UrlOrString):
+        page_num = int(re.search(r'.*[?&]p=(\d+)', UrlOrString).groups()[0])
+
+    assert bvid or aid, "url is not a valid bilibili video url"
+
+    return aid, bvid, page_num

--- a/bilix/sites/bilibili/utils.py
+++ b/bilix/sites/bilibili/utils.py
@@ -1,9 +1,9 @@
 import re
 
 
-def parse_ids_from_url(UrlOrString: str):
+def parse_ids_from_url(url_or_string: str):
     """
-    aid, bvid, page_num = parse_ids_from_url(UrlOrString)
+    aid, bvid, page_num = parse_ids_from_url(url_or_string)
 
     例如：
     ```
@@ -19,18 +19,18 @@ def parse_ids_from_url(UrlOrString: str):
     """
 
     bvid = aid = page_num = None
-    if re.match(r'https?://www.bilibili.com/video/BV\w+', UrlOrString) or re.match(r'BV\w+', UrlOrString):
-        bvid = re.search(r'BV(\w+)', UrlOrString).groups()[0]
+    if re.match(r'https?://www.bilibili.com/video/BV\w+', url_or_string) or re.match(r'BV\w+', url_or_string):
+        bvid = re.search(r'BV(\w+)', url_or_string).groups()[0]
         assert bvid.isalnum()
         assert isinstance(bvid, str)
-    elif re.match(r'https?://www.bilibili.com/video/av\d+', UrlOrString) or re.match(r'av\d+', UrlOrString):
-        aid = re.search(r'av(\d+)', UrlOrString).groups()[0]
+    elif re.match(r'https?://www.bilibili.com/video/av\d+', url_or_string) or re.match(r'av\d+', url_or_string):
+        aid = re.search(r'av(\d+)', url_or_string).groups()[0]
         assert aid.isdigit()
         aid = int(aid)
 
     # ?p=123 or &p=123
-    if re.match(r'.*[?&]p=(\d+)', UrlOrString):
-        page_num = int(re.search(r'.*[?&]p=(\d+)', UrlOrString).groups()[0])
+    if re.match(r'.*[?&]p=(\d+)', url_or_string):
+        page_num = int(re.search(r'.*[?&]p=(\d+)', url_or_string).groups()[0])
 
     assert bvid or aid, "url is not a valid bilibili video url"
 

--- a/bilix/sites/bilibili/utils.py
+++ b/bilix/sites/bilibili/utils.py
@@ -20,7 +20,7 @@ def parse_ids_from_url(url_or_string: str):
 
     bvid = aid = page_num = None
     if re.match(r'https?://www.bilibili.com/video/BV\w+', url_or_string) or re.match(r'BV\w+', url_or_string):
-        bvid = re.search(r'BV(\w+)', url_or_string).groups()[0]
+        bvid = re.search(r'(BV\w+)', url_or_string).groups()[0]
         assert bvid.isalnum()
         assert isinstance(bvid, str)
     elif re.match(r'https?://www.bilibili.com/video/av\d+', url_or_string) or re.match(r'av\d+', url_or_string):

--- a/bilix/sites/bilibili/utils_test.py
+++ b/bilix/sites/bilibili/utils_test.py
@@ -1,0 +1,19 @@
+import pytest
+
+from bilix.sites.bilibili.utils import parse_ids_from_url
+
+def test_parse_ids_from_url():
+    strings = [
+        "https://www.bilibili.com/video/av170001",
+        "http://www.bilibili.com/video/BV1Xx41117Tz/?ba=labala&p=3#time=1234",
+        "av170001",
+        "BV1sE411w7tQ?p=2&from=search",
+        ]
+    results = [
+        (170001, None, None),
+        (None, 'BV1Xx41117Tz', 3),
+        (170001, None, None),
+        (None, 'BV1sE411w7tQ', 2),
+        ]
+    for index, string in enumerate(strings):
+        assert parse_ids_from_url(string) == results[index]


### PR DESCRIPTION
BiliBili 的网页前端风控和 API 风控似乎是分开的，网页访问被 ban 时，API 多半依然有效。
因为 bilix 是直接解析的视频页 HTML，我前几天网页访问被弹验证码之后发现 API 依然可用，于是就有了这个 PR 。

从 API 获取视频流地址比直接解析 HTML 稳定，因为有些上古老视频的网页内嵌 json 只给 durl 资源，而走 API 能主动获取到 dash 。

`pytest api_test.py` 除了 `test_get_list_info` 这一项没过（不过看起来它与这个 PR 无关），其它都通过了。

NOTE: 只实现了一般的 av/bv 视频的 API 解析，ep 仍会使用访问网页解析 HTML 的方式。