### PR TITLE
bilibili improve

### DIFF
--- a/bilix/sites/bilibili/api.py
+++ b/bilix/sites/bilibili/api.py
@@ -326,6 +326,7 @@ class VideoInfo(BaseModel):
 
     @staticmethod
     def parse_html(url, html: str):
+        _, _, selected_page_num = parse_ids_from_url(url)
         if "window._riskdata_" in html:
             raise APIBannedError("web 前端访问被风控", url)
         init_info = re.search(r'<script>window.__INITIAL_STATE__=({.*});\(', html).groups()[0]  # this line may raise
@@ -339,14 +340,19 @@ class VideoInfo(BaseModel):
             status = Status(**init_info['videoData']['stat'])
             bvid = init_info['bvid']
             aid = init_info['aid']
-            (p, cid), = init_info['cidMap'][bvid]['cids'].items()
-            p = int(p) - 1
             title = legal_title(init_info['videoData']['title'])
             base_url = url.split('?')[0]
+            p = None
+            cid = None
             for idx, i in enumerate(init_info['videoData']['pages']):
-                p_url = f"{base_url}?p={idx + 1}"
-                p_name = f"P{idx + 1}-{i['part']}" if len(init_info['videoData']['pages']) > 1 else ''
+                page_num = i['page']  # type: int
+                if page_num == selected_page_num:
+                    p = idx
+                    cid = i['cid']
+                p_url = f"{base_url}?p={page_num}"
+                p_name = f"P{page_num}-{i['part']}" if len(init_info['videoData']['pages']) > 1 else ''
                 pages.append(Page(p_name=p_name, p_url=p_url))
+            assert p is not None, f"没有找到分P: p{selected_page_num}，请检查输入"  # cid 也会是 None
         elif 'initEpList' in init_info:  # 动漫，电视剧，电影
             stat = init_info['mediaInfo']['stat']
             status = Status(

--- a/bilix/sites/bilibili/api.py
+++ b/bilix/sites/bilibili/api.py
@@ -399,7 +399,7 @@ async def get_video_info(client: httpx.AsyncClient, url: str) -> VideoInfo:
         return await _get_video_info_from_html(client, url)
     except APIBannedError:
         # try to get video info from api if web front-end is banned
-        await _get_video_info_from_api(client, url)
+        return await _get_video_info_from_api(client, url)
 
 
 async def _get_video_info_from_html(client: httpx.AsyncClient, url: str) -> VideoInfo:

--- a/bilix/sites/bilibili/utils.py
+++ b/bilix/sites/bilibili/utils.py
@@ -15,5 +15,5 @@ def parse_ids_from_url(url_or_string: str):
     # ?p=123 or &p=123
     if m := re.match(r'.*[?&]p=(\d+)', url_or_string):
         page_num = int(m.groups()[0])
-        assert page_num > 1
+        assert page_num >= 1
     return aid, bvid, page_num

--- a/bilix/sites/bilibili/utils_test.py
+++ b/bilix/sites/bilibili/utils_test.py
@@ -7,12 +7,14 @@ def test_parse_ids_from_url():
         "http://www.bilibili.com/video/BV1Xx41117Tz/?ba=labala&p=3#time=1234",
         "av170001",
         "BV1sE411w7tQ?p=2&from=search",
+        "https://www.bilibili.com/video/BV1xx411c7HW?p=1"
     ]
     results = [
         (170001, None, 1),
         (None, 'BV1Xx41117Tz', 3),
         (170001, None, 1),
         (None, 'BV1sE411w7tQ', 2),
+        (None, 'BV1xx411c7HW', 1)
     ]
     for index, string in enumerate(strings):
         assert parse_ids_from_url(string) == results[index]


### PR DESCRIPTION
* `get_video_info()` 缺个 return :rofl: 
* BiliBili 在多P视频里会出现 `p=1` 这样的 URL，而且不会被重定向到无 `p=` 参数的`干净URL`，比如：<https://www.bilibili.com/video/BV1ss4y1k7CD?p=1> ，电脑网页右侧的分 P 栏中的 P1 就是 `?p=1` 这样的形式。既然合法，那就解析呗。
![BiliBili_p1_url](https://github.com/HFrost0/bilix/assets/30341059/eef198d3-2272-46ba-b0b8-5964ddeb866c)  
* 我担心如果有些视频的一些分P被和谐/删除，中间的一些分P可能会缺，于是 bilix 生成的 `<主标题>-P<分P号>-<分P标题>.mp4` 文件名就可能和实际分 P 不符，毕竟现在是用 index 推算的。所以把 `parse_html()` 改成和 `_get_video_basic_info_from_api()` 一样，从 `init_info['videoData']['pages']` 直接获取分P号和对应的 cid 。  
  > 但是我没找到缺分P的视频例子，所以不知道这个假设对不对。