### PR TITLE
fix: support Python 3.13 (resolve #202)

### DIFF
--- a/bilix/download/base_downloader_part.py
+++ b/bilix/download/base_downloader_part.py
@@ -7,7 +7,7 @@ import httpx
 import uuid
 import random
 import os
-import cgi
+from email.message import Message
 from pymp4.parser import Box
 from bilix.download.base_downloader import BaseDownloader
 from bilix.download.utils import path_check, merge_files
@@ -48,8 +48,9 @@ class BaseDownloaderPart(BaseDownloader):
         total = int(res.headers['Content-Range'].split('/')[-1])
         # get filename
         if content_disposition := res.headers.get('Content-Disposition', None):
-            key, pdict = cgi.parse_header(content_disposition)
-            filename = pdict.get('filename', '')
+            m = Message()
+            m['content-type'] = content_disposition
+            filename = m.get_param('filename', '')
         else:
             filename = ''
         # change origin url to redirected position to avoid twice redirect


### PR DESCRIPTION
As reported in #202, bilix does not work using [Python 3.13.0a2](https://www.python.org/downloads/release/python-3130a2/).

This PR addresses the removal of the `cgi` module in Python 3.13, which has been deprecated since Python 3.11, by replacing `cgi.parse_header` with `email.message.Message` as recommended in [PEP 594](https://peps.python.org/pep-0594/).

This issue was originally reported by @gridkr in https://github.com/saveweb/biliarchiver/issues/14.