### PR TITLE
perf(build): use beautifulsoup4 directly

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = [
     "aiofiles>=0.8.0",
     "anyio",
     "danmakuC>=0.3.5",
-    "bs4",
+    "beautifulsoup4",
     "click>=8.0.3",
     "httpx[http2]>=0.23.3",
     "json5",


### PR DESCRIPTION
根据Pypi显示的信息来看，[bs4](https://pypi.org/project/bs4)为[beautifulsoup4](https://pypi.org/project/beautifulsoup4)的虚包，我们应该避免引用该包而是直接使用其本身
