### PR TITLE
Update api.py greedy matching to non-greedy matching 

### DIFF
--- a/bilix/sites/bilibili/api.py
+++ b/bilix/sites/bilibili/api.py
@@ -369,7 +369,7 @@ def _parse_bv_html(url, html: str) -> VideoInfo:
         pages.append(Page(p_name=p_name, p_url=p_url))
     # extract dash and flv_url
     dash, other = None, []
-    play_info = re.search('<script>window.__playinfo__=({.*})</script><script>', html).groups()[0]
+    play_info = re.search('<script>window.__playinfo__=({.*?})</script><script>', html).groups()[0]
     play_info = json.loads(play_info)['data']
     try:
         dash = Dash.from_dict(play_info)


### PR DESCRIPTION
匹配bilibili返回的html中。一段正则是贪婪模式，导致返回的结果不是json（因为bilibili调整了页面的代码）。调整成非贪婪模式。