### PR TITLE
fix: bilibili play_info api

### DIFF
--- a/bilix/sites/bilibili/api.py
+++ b/bilix/sites/bilibili/api.py
@@ -346,7 +346,7 @@ class VideoInfo(BaseModel):
     tags: Optional[List[str]] = None
 
 
-def _parse_bv_html(url, html: str) -> VideoInfo:
+async def _parse_bv_html(client: httpx.AsyncClient,url, html: str) -> VideoInfo:
     init_info = re.search(r'<script>window.__INITIAL_STATE__=({.*?});\(', html).groups()[0]  # this line may raise
     init_info = json.loads(init_info)
     if len(init_info.get('error', {})) > 0:
@@ -369,8 +369,8 @@ def _parse_bv_html(url, html: str) -> VideoInfo:
         pages.append(Page(p_name=p_name, p_url=p_url))
     # extract dash and flv_url
     dash, other = None, []
-    play_info = re.search('<script>window.__playinfo__=({.*?})</script><script>', html).groups()[0]
-    play_info = json.loads(play_info)['data']
+    play_info = await req_retry(client, f'https://api.bilibili.com/x/player/wbi/playurl?bvid={bvid}&cid={cid}&fnval=4048')
+    play_info = json.loads(play_info.text)['data']
     try:
         dash = Dash.from_dict(play_info)
     except KeyError:
@@ -442,7 +442,7 @@ async def _get_video_info_from_html(client: httpx.AsyncClient, url: str) -> Vide
     if "window._riskdata_" in html:
         raise APIInvalidError("web 前端访问被风控", url)
     if "window.__INITIAL_STATE__" in html:
-        return _parse_bv_html(url, html)
+        return await _parse_bv_html(client, url, html)
     elif "__NEXT_DATA__" in html:
         video_info = _parse_ep_html(url, html)
         await _attach_ep_dash(client, video_info)


### PR DESCRIPTION
之前获取play_info的方法已失效，页面上的`window.__playinfo__`消失了，这个PR更新了获取play_info的方式。

相关issue：#243