### PR TITLE
(fix) normalize relative subtitle urls and add regression test

### DIFF
--- a/bilix/sites/bilibili/api.py
+++ b/bilix/sites/bilibili/api.py
@@ -1,7 +1,7 @@
 import asyncio
 import json
 import re
-from urllib.parse import quote
+from urllib.parse import quote, urljoin
 import httpx
 from pydantic import field_validator, BaseModel, Field
 from typing import Union, List, Tuple, Dict, Optional
@@ -536,6 +536,16 @@ async def _get_video_basic_info_from_api(client: httpx.AsyncClient, url) -> Vide
     return basic_video_info
 
 
+def _normalize_subtitle_url(subtitle_url: str) -> str:
+    if subtitle_url.startswith('//'):
+        return 'http:' + subtitle_url
+    if subtitle_url.startswith('/'):
+        return urljoin('https://www.bilibili.com', subtitle_url)
+    if not subtitle_url.startswith('http'):
+        return 'http://' + subtitle_url
+    return subtitle_url
+
+
 @raise_api_error
 async def get_subtitle_info(client: httpx.AsyncClient, bvid, cid):
     params = {'bvid': bvid, 'cid': cid}
@@ -543,7 +553,7 @@ async def get_subtitle_info(client: httpx.AsyncClient, bvid, cid):
     info = json.loads(res.text)
     if info['code'] == -400:
         raise APIError(f'未找到字幕信息', params)
-    return [[f'http:{i["subtitle_url"]}', i['lan_doc']] for i in info['data']['subtitle']['subtitles']]
+    return [[_normalize_subtitle_url(i['subtitle_url']), i['lan_doc']] for i in info['data']['subtitle']['subtitles']]
 
 
 @raise_api_error

--- a/bilix/sites/bilibili/api_test.py
+++ b/bilix/sites/bilibili/api_test.py
@@ -122,6 +122,13 @@ async def test_get_subtitle_info():
     assert data[0][1]
 
 
+def test_normalize_subtitle_url():
+    assert api._normalize_subtitle_url('//test.com/subtitle.vtt') == 'http://test.com/subtitle.vtt'
+    assert api._normalize_subtitle_url('/subtitles/1.json') == 'https://www.bilibili.com/subtitles/1.json'
+    assert api._normalize_subtitle_url('https://test.com/file') == 'https://test.com/file'
+    assert api._normalize_subtitle_url('test.com/file') == 'http://test.com/file'
+
+
 @pytest.mark.asyncio
 async def test_get_dm_info():
     data = await api.get_video_info(client,


### PR DESCRIPTION
### Summary
This PR is focused on stabilizing subtitle URL processing for Bilibili and preventing invalid HTTP requests during subtitle download. It fixes Bilibili subtitle download crash caused by relative or scheme-relative subtitle URLs returned by the Bilibili API.

### Changes
- `bilix/sites/bilibili/api.py`
  - Added `_normalize_subtitle_url(...)`
  - Normalizes subtitle URLs before returning them from `get_subtitle_info`
  - Handles:
    - `//...` > `http://...`
    - `/...` > `https://www.bilibili.com/...`
    - bare host paths > `http://...`

- `bilix/sites/bilibili/api_test.py`
  - Added `test_normalize_subtitle_url()`
  - Covers the new URL normalization logic

### Reasoning
When a requested quality is unavailable, the Bilibili subtitle API can return malformed or relative subtitle URLs. Those URLs are passed directly into `get_static()`, producing invalid request URLs like `'/'` and causing a hard failure instead of a graceful fallback or error message.

### Validation
  - `python3 -m py_compile api.py sites/bilibili/api_test.py`
